### PR TITLE
Update wordpress-meetups-switzerland.md

### DIFF
--- a/wordpress-meetups-switzerland.md
+++ b/wordpress-meetups-switzerland.md
@@ -16,13 +16,21 @@ Please submit changes and additions to this repository via Patch or Pull Request
 
 - WebDev Meetup Chur [on Meetup.com](https://www.meetup.com/WebDev-Chur/)
 
+#### Fribourg
+
+- WebDev Meetup Fribourg [on Meetup.com](https://www.meetup.com/Fribourg-WordPress-Meetup/)
+
 #### Geneva
 
-- WordPress Meetup Geneva [on Meetup.com](https://www.meetup.com/geneva-wordpress/) / [website](https://wpgva.ch/)
+- WordPress Meetup Geneva [on Meetup.com](https://www.meetup.com/geneva-wordpress/)
 
 #### Lausanne
 
 - WordPress Meetup Lausanne [on Meetup.com](https://www.meetup.com/Lausanne-WordPress-Meetup/)
+
+#### Lugano
+
+- WordPress Meetup Lugano [on Meetup.com](https://www.meetup.com/Lugano-WordPress-Meetup/)
 
 #### Luzern
 


### PR DESCRIPTION
added Fribourg and Lugano meetups, removed Geneva website link