### PR TITLE
Added BlueGlass ¦ Team Farner as WordPress Agency

### DIFF
--- a/wordpress-developers-and-agencies-switzerland.md
+++ b/wordpress-developers-and-agencies-switzerland.md
@@ -6,6 +6,7 @@ Please submit changes and additions to this repository via Patch or Pull Request
 
 ## Agencies
 - [Blueforce Internet Solutions](https://www.blueforce.ch/) - [@blueforce1](https://twitter.com/blueforce1)
+- [BlueGlass | Team Farner](https://www.blueglass.ch/) - [@blueglass-zuerich](https://www.linkedin.com/company/blueglass-zuerich/)
 - [CLUS Werbeagentur](https://clus.ch/) - [@clus_ch](https://twitter.com/clus_ch)
 - [Comotive](https://www.comotive.ch/)
 - [cubetech](https://www.cubetech.ch/) - [@cubetech_ch](https://twitter.com/cubetech_ch)


### PR DESCRIPTION
Added BlueGlass ¦ Team Farner to wordpress-developers-and-agencies-switzerland.md